### PR TITLE
feat: add ability to track last update check as mod metadata

### DIFF
--- a/code/commandline.py
+++ b/code/commandline.py
@@ -127,12 +127,21 @@ def process_commandline_args() -> Namespace:
     list_subparsers.add_parser("conflicts",
                                formatter_class=ArgumentDefaultsHelpFormatter,
                                help="List possible conflicts between all installed mods")
+    list_update_parser = list_subparsers.add_parser("updatecheck",
+                                                    formatter_class=ArgumentDefaultsHelpFormatter,
+                                                    help="List of mods sorted by the last time they were checked for update")
+    list_update_parser.add_argument("--all",
+                                    action="store_true")
+    list_update_parser.add_argument("modids",
+                                    nargs="*",
+                                    default=[],
+                                    type=cast_validate_mod_id)
     list_version_parser = list_subparsers.add_parser("versions",
                                                      formatter_class=ArgumentDefaultsHelpFormatter,
                                                      help="List the mods")
     list_version_parser.add_argument("--all",
                                      action="store_true")
-    list_version_parser.add_argument("mod_id",
+    list_version_parser.add_argument("modids",
                                      nargs='*',
                                      default=[],
                                      type=cast_validate_mod_id)
@@ -200,6 +209,11 @@ def process_commandline_args() -> Namespace:
     mod_set_parser.add_argument("attribute", choices={"author", "name", "note", "link"})
     mod_set_parser.add_argument("value")
     mod_action_parsers.add_parser("info")
+    markuptodate_parser = subparsers.add_parser("markuptodate")
+    markuptodate_parser.add_argument("modids",
+                                     nargs='+',
+                                     default=[],
+                                     type=cast_validate_mod_id)
     subparsers.add_parser("help",
                           formatter_class=ArgumentDefaultsHelpFormatter,
                           help="Show this help information")

--- a/code/mod.py
+++ b/code/mod.py
@@ -317,6 +317,9 @@ class ValidModSettings(Enum):
         lambda url: url == "" or match(r"^[\s]+", url, NOFLAG) is None,
         lambda url: url == "" or search(r"[\s]+$", url, NOFLAG) is None,
     })
+    LAST_UPDATE_CHECK = ("last_update_check", str, "", {
+        lambda s: s == "" or match("[0-9]{4}-[0-9]{2}-[0-9]{2}", s, NOFLAG) is not None
+    })
 
 
 def default_mod_settings() -> dict[str, Any]:
@@ -398,3 +401,24 @@ def attempt_instance_relative_cast(path: Path, base_dir: Path | None = None) -> 
         return path.resolve().relative_to(instance_path)
     except ValueError:
         return path
+
+
+def get_mod_last_update_check(mod_id: str, base_dir: Path | None = None) -> str | None:
+    """
+
+    :param mod_id:
+    :type mod_id:
+    :param base_dir:
+    :type base_dir:
+    :return:
+    :rtype:
+    """
+    stored_date: str = ModConfig(mod_id, base_dir).get(ValidModSettings.LAST_UPDATE_CHECK)
+    if stored_date is not None and stored_date != "":
+        return stored_date
+    else:
+        latest_version = select_latest_version(mod_id, base_dir)
+        if latest_version is not None:
+            return latest_version[0]
+        else:
+            return None


### PR DESCRIPTION
This commit introduces a new value to the mod metadata file format "last_update_check" which can contain the date of the last time the mod was updated or manually marked as up-to-date using the new subcommand "markuptodate".

In order to make this new information fields useful, the commit also adds the subcommands "list updatecheck", which prints a formatted list of update dates sorted chronologically and their respective mods. The last updated date of a specific mod has also been added to the output of the "mod <mod> info" subcommand.
If no last updated date is saved, modfs falls back to the date of the latest currently installed mod - please be aware that this fallback may be impacted by the deletion of specific versions.

If neither the metadata field, nor any version of the mod exists, there's some special case handling attached to gracefully deal with the issue.