### PR TITLE
fix(import): missing resolving of given import source path

### DIFF
--- a/code/subcommands.py
+++ b/code/subcommands.py
@@ -201,7 +201,7 @@ def subcommand_import(args: SubcommandArgDict) -> None:
     else:
         print(f"Importing mod {mod_id}")
 
-    source: Path = args["import_path"]
+    source: Path = args["import_path"].resolve(strict=True)
     raw_destination = create_mod_space(mod_id).resolve()
     processed_subdir = process_mod_subdir_argument(args["subdir"],
                                                    mod_id=mod_id,


### PR DESCRIPTION
This bug could cause errors when given source paths like ".", to import
the current directory, since some code assumes the path should be
able to be analyzed and taken apart.

Better to sanitize early, than to attempt plugging every potentially
incorrect logic assumption later.

Signed-off-by: Jonas Tobias Hopusch <git@jotoho.de>
Resolves: https://github.com/jotoho/modfs/issues/33
